### PR TITLE
Security hardening, new features, and operational improvements

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-push:
     name: Build and push dev Docker image
@@ -17,14 +21,15 @@ jobs:
 
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push dmarc-monitor dev image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ secrets.DOCKER_USERNAME }}/dmarc-monitor:dev
+          tags: ghcr.io/${{ github.repository }}:dev
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,26 +1,30 @@
 name: "DMARC-monitor - development"
 
-# only execute workflow on the master branch
 on:
   push:
     branches: main
 
 jobs:
-  buildAndPublish:
-    name: Build and publish dev docker
+  build-and-push:
+    name: Build and push dev Docker image
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      # build dmarc-monitor image and push it to docker hub
-      - name: Build and push dmarc-monitor image
-        uses: docker/build-push-action@v6
+
+      - name: Build and push dmarc-monitor dev image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ secrets.DOCKER_USERNAME }}/dmarc-monitor:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -1,43 +1,71 @@
 name: "DMARC-monitor - releases"
 
-# only execute workflow on the master branch
 on:
   push:
     tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  contents: write
+
 jobs:
-  dmarc-monitor:
-    name: Build and publish dmarc-monitor
+  release:
+    name: Build, scan, and release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Set release version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      # build dmarc-monitor image and push it to docker hub
-      - name: Build and push dmarc-monitor image
-        uses: docker/build-push-action@v6
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/dmarc-monitor
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push release image
+        id: push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/dmarc-monitor:${{ env.RELEASE_VERSION }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-  release_dmarc-monitor:
-    name: Release dmarc-monitor
-    runs-on: ubuntu-latest
-    needs: [dmarc-monitor]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      # release a new version on github
-      - name: Release
-        uses: docker://antonyurchenko/git-release:latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CHANGELOG_FILE: none
-          RELEASE_NAME_PREFIX: "Release "
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ secrets.DOCKER_USERNAME }}/dmarc-monitor@${{ steps.push.outputs.digest }}
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ secrets.DOCKER_USERNAME }}/dmarc-monitor@${{ steps.push.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-release-assets: false
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          generate_release_notes: true
+          files: sbom.spdx.json

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -22,14 +23,15 @@ jobs:
 
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ${{ secrets.DOCKER_USERNAME }}/dmarc-monitor
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -49,7 +51,7 @@ jobs:
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ secrets.DOCKER_USERNAME }}/dmarc-monitor@${{ steps.push.outputs.digest }}
+          image-ref: ghcr.io/${{ github.repository }}@${{ steps.push.outputs.digest }}
           format: table
           exit-code: '1'
           ignore-unfixed: true
@@ -59,7 +61,7 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ${{ secrets.DOCKER_USERNAME }}/dmarc-monitor@${{ steps.push.outputs.digest }}
+          image: ghcr.io/${{ github.repository }}@${{ steps.push.outputs.digest }}
           format: spdx-json
           output-file: sbom.spdx.json
           upload-release-assets: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Main configuration file, could have secrets
+config.toml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 config.toml
+data/*
+!data/.gitkeep
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-# Main configuration file, could have secrets
 config.toml
 
 # Byte-compiled / optimized / DLL files

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 docker-compose.dev.yml
+
+# data
+data/
+!/data/.gitkeep

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Copy the requirements and install dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY pyproject.toml .
+RUN pip install --no-cache-dir .
 
 # Copy the Python script
 COPY dmarc_monitor.py .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,9 @@ COPY pyproject.toml .
 RUN pip install --no-cache-dir .
 
 # Copy the Python script
-COPY dmarc_monitor.py .
+COPY --chmod=0755 dmarc_monitor.py .
 
 # Expose port 8000 for Prometheus metrics
 EXPOSE 8000
 
-# Run the script permanently
-CMD ["python", "dmarc_monitor.py"]
+ENTRYPOINT ["/app/dmarc_monitor.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
-# Use a lightweight Python base image
-FROM python:3.11-slim
+FROM python:3.13-slim
 
-# Set the working directory inside the container
 WORKDIR /app
 
-# Copy the requirements and install dependencies
-COPY pyproject.toml .
-RUN pip install --no-cache-dir .
+COPY pyproject.toml dmarc_monitor.py ./
 
-# Copy the Python script
-COPY --chmod=0755 dmarc_monitor.py .
+RUN pip install --no-cache-dir . && \
+    groupadd --system appgroup && \
+    useradd --system --gid appgroup --no-create-home appuser
 
-# Expose port 8000 for Prometheus metrics
+USER appuser
+
 EXPOSE 8000
 
-ENTRYPOINT ["/app/dmarc_monitor.py"]
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/')" || exit 1
+
+ENTRYPOINT ["dmarc-monitor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
+ENV PYTHONUNBUFFERED=1
+
 COPY pyproject.toml dmarc_monitor.py ./
 
 RUN pip install --no-cache-dir . && \

--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ http://localhost:8000/metrics
 ```
 
 ### **Available Metrics**
-| Metric Name                    | Description                                    | Labels (`domain`, `provider`, `report_id`, `report_date`) |
-|---------------------------------|------------------------------------------------|-----------------------------------------------------------|
-| `dmarc_passed_count`           | Number of emails that **passed** DMARC        | ✅ |
-| `dmarc_failed_count`           | Number of emails that **failed** DMARC        | ✅ |
-| `last_processed_timestamp`     | Timestamp of last processed DMARC report      | ✅ |
+| Metric Name                              | Description                              | Labels (`domain`, `provider`, `report_id`, `report_date`) |
+|------------------------------------------|------------------------------------------|-----------------------------------------------------------|
+| `dmarc_passed_count`                     | Number of emails that **passed** DMARC   | ✅                                                        |
+| `dmarc_failed_count`                     | Number of emails that **failed** DMARC   | ✅                                                        |
+| `dmarc_last_processed_timestamp_seconds` | Timestamp of last processed DMARC report | ✅                                                        |
 
 Example Output:
 ```
 dmarc_passed_count{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 500
 dmarc_failed_count{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 20
-last_processed_timestamp{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 1708334567.123
+dmarc_last_processed_timestamp_seconds{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 1708334567.123
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@ DMARC Monitor is a **Prometheus-exporting service** that automatically fetches D
 
 ## Features 🚀
 
-✅ **Automatically fetches DMARC reports** from email attachments (`.zip` or `.gz`).  
-✅ **Parses XML reports** and extracts relevant metrics.  
-✅ **Exposes DMARC data** via a **Prometheus metrics endpoint (`:8000/metrics`)**.  
-✅ **Removes unnecessary namespaces (`xmlns`)** for compatibility.  
-✅ **Deployable via Docker and Docker Compose** for ease of use.  
-✅ **Uses environment variables for secure configuration** instead of `.env`.  
-✅ **Supports Grafana for visualization** of DMARC trends over time.  
+✅ **Automatically fetches DMARC reports** from email attachments (`.zip` or `.gz`).
+✅ **Parses XML reports** and extracts relevant metrics.
+✅ **Exposes DMARC data** via a **Prometheus metrics endpoint (`:8000/metrics`)**.
+✅ **Removes unnecessary namespaces (`xmlns`)** for compatibility.
+✅ **Deployable via Docker and Docker Compose** for ease of use.
+✅ **Supports Grafana for visualization** of DMARC trends over time.
 
 ---
 
@@ -51,14 +50,8 @@ cd dmarc-monitor
 ```
 
 ### **2️⃣ Set Up Docker Compose**
-#### **Modify `docker-compose.yml` with Your Email Credentials**
-Edit the `environment` section in `docker-compose.yml`:
-```yaml
-environment:
-  EMAIL_USER: "your-email@example.com"
-  EMAIL_PASS: "your-email-password"
-  IMAP_SERVER: "imap.example.com"
-```
+#### **Copy config.example.toml to config.toml**
+Edit the config file with your credentials and customization:
 
 ### **3️⃣ Build & Start the Service**
 ```sh
@@ -107,13 +100,7 @@ sum(dmarc_failed_count) by (domain)
 
 ## **Configuration Options**
 
-You can **modify the environment variables** to customize the setup:
-
-| Variable     | Description                                  | Example Value              |
-|-------------|----------------------------------------------|----------------------------|
-| `EMAIL_USER` | Email address to fetch DMARC reports from | `your-email@example.com`   |
-| `EMAIL_PASS` | Email password (or App Password)          | `your-email-password`      |
-| `IMAP_SERVER` | IMAP server for your email provider       | `imap.gmail.com`           |
+The config.example.toml file has commented options and defaults.
 
 💡 **Tip:** If using Gmail, generate an **App Password** instead of using your real password.
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ DMARC Monitor is a **Prometheus-exporting service** that automatically fetches D
 
 ## Features 🚀
 
-✅ **Automatically fetches DMARC reports** from email attachments (`.zip` or `.gz`).
-✅ **Parses XML reports** and extracts relevant metrics.
-✅ **Exposes DMARC data** via a **Prometheus metrics endpoint (`:8000/metrics`)**.
-✅ **Removes unnecessary namespaces (`xmlns`)** for compatibility.
-✅ **Deployable via Docker and Docker Compose** for ease of use.
-✅ **Supports Grafana for visualization** of DMARC trends over time.
+✅ **Automatically fetches DMARC reports** from email attachments (`.zip` or `.gz`).  
+✅ **Parses XML reports** and extracts relevant metrics.  
+✅ **Exposes DMARC data** via a **Prometheus metrics endpoint (`:8000/metrics`)**.  
+✅ **Removes unnecessary namespaces (`xmlns`)** for compatibility.  
+✅ **Deployable via Docker and Docker Compose** for ease of use.  
+✅ **Uses environment variables for secure configuration** instead of `.env`.  
+✅ **Supports Grafana for visualization** of DMARC trends over time.  
 
 ---
 
@@ -26,17 +27,17 @@ http://localhost:8000/metrics
 ```
 
 ### **Available Metrics**
-| Metric Name                              | Description                              | Labels (`domain`, `provider`, `report_id`, `report_date`) |
-|------------------------------------------|------------------------------------------|-----------------------------------------------------------|
-| `dmarc_passed_count`                     | Number of emails that **passed** DMARC   | ✅                                                        |
-| `dmarc_failed_count`                     | Number of emails that **failed** DMARC   | ✅                                                        |
-| `dmarc_last_processed_timestamp_seconds` | Timestamp of last processed DMARC report | ✅                                                        |
+| Metric Name                    | Description                                    | Labels (`domain`, `provider`, `report_id`, `report_date`) |
+|---------------------------------|------------------------------------------------|-----------------------------------------------------------|
+| `dmarc_passed_count`           | Number of emails that **passed** DMARC        | ✅ |
+| `dmarc_failed_count`           | Number of emails that **failed** DMARC        | ✅ |
+| `last_processed_timestamp`     | Timestamp of last processed DMARC report      | ✅ |
 
 Example Output:
 ```
 dmarc_passed_count{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 500
 dmarc_failed_count{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 20
-dmarc_last_processed_timestamp_seconds{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 1708334567.123
+last_processed_timestamp{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 1708334567.123
 ```
 
 ---
@@ -50,8 +51,14 @@ cd dmarc-monitor
 ```
 
 ### **2️⃣ Set Up Docker Compose**
-#### **Copy config.example.toml to config.toml**
-Edit the config file with your credentials and customization:
+#### **Modify `docker-compose.yml` with Your Email Credentials**
+Edit the `environment` section in `docker-compose.yml`:
+```yaml
+environment:
+  EMAIL_USER: "your-email@example.com"
+  EMAIL_PASS: "your-email-password"
+  IMAP_SERVER: "imap.example.com"
+```
 
 ### **3️⃣ Build & Start the Service**
 ```sh
@@ -100,7 +107,13 @@ sum(dmarc_failed_count) by (domain)
 
 ## **Configuration Options**
 
-The config.example.toml file has commented options and defaults.
+You can **modify the environment variables** to customize the setup:
+
+| Variable     | Description                                  | Example Value              |
+|-------------|----------------------------------------------|----------------------------|
+| `EMAIL_USER` | Email address to fetch DMARC reports from | `your-email@example.com`   |
+| `EMAIL_PASS` | Email password (or App Password)          | `your-email-password`      |
+| `IMAP_SERVER` | IMAP server for your email provider       | `imap.gmail.com`           |
 
 💡 **Tip:** If using Gmail, generate an **App Password** instead of using your real password.
 

--- a/README.md
+++ b/README.md
@@ -1,152 +1,153 @@
 
-### **README.md**
-
-# DMARC Monitor 📊
+# DMARC Monitor
 
 ## Overview
 
 DMARC Monitor is a **Prometheus-exporting service** that automatically fetches DMARC (Domain-based Message Authentication, Reporting & Conformance) reports from an **email inbox**, extracts key metrics, and exposes them for monitoring via Prometheus. These metrics can then be visualized using **Grafana** or another dashboard tool.
 
-## Features 🚀
+## Features
 
-✅ **Automatically fetches DMARC reports** from email attachments (`.zip` or `.gz`).  
-✅ **Parses XML reports** and extracts relevant metrics.  
-✅ **Exposes DMARC data** via a **Prometheus metrics endpoint (`:8000/metrics`)**.  
-✅ **Removes unnecessary namespaces (`xmlns`)** for compatibility.  
-✅ **Deployable via Docker and Docker Compose** for ease of use.  
-✅ **Uses environment variables for secure configuration** instead of `.env`.  
-✅ **Supports Grafana for visualization** of DMARC trends over time.  
+- Automatically fetches DMARC reports from email attachments (`.zip` or `.gz`)
+- Parses XML reports and extracts relevant metrics
+- Exposes DMARC data via a **Prometheus metrics endpoint** (`:8000/metrics`)
+- Removes unnecessary `xmlns` namespaces for XML compatibility
+- Deployable via Docker and Docker Compose
+- Configured via a TOML file (see `config.example.toml`)
+- Supports Grafana for visualization of DMARC trends over time
 
 ---
 
-## **Metrics Exposed in Prometheus**
+## Metrics Exposed in Prometheus
 
-Once the service is running, you can query **Prometheus metrics** at:
+Once the service is running, metrics are available at:
 ```
 http://localhost:8000/metrics
 ```
 
-### **Available Metrics**
-| Metric Name                    | Description                                    | Labels (`domain`, `provider`, `report_id`, `report_date`) |
-|---------------------------------|------------------------------------------------|-----------------------------------------------------------|
-| `dmarc_passed_count`           | Number of emails that **passed** DMARC        | ✅ |
-| `dmarc_failed_count`           | Number of emails that **failed** DMARC        | ✅ |
-| `last_processed_timestamp`     | Timestamp of last processed DMARC report      | ✅ |
+### Available Metrics
 
-Example Output:
+| Metric Name                              | Type    | Description                                          | Labels                        |
+|------------------------------------------|---------|------------------------------------------------------|-------------------------------|
+| `dmarc_reports_total`                    | Counter | DMARC disposition counts from processed reports      | `domain`, `provider`, `disposition` |
+| `dmarc_last_processed_timestamp_seconds` | Gauge   | Unix timestamp of the last processed DMARC report    | `domain`, `provider`          |
+
+The `disposition` label reflects the DMARC policy outcome:
+- `none` — email passed (no action taken)
+- `quarantine` — soft-fail
+- `reject` — hard-fail
+
+Example output:
 ```
-dmarc_passed_count{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 500
-dmarc_failed_count{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 20
-last_processed_timestamp{domain="example.com", provider="Google", report_id="123456789", report_date="2025-02-18"} 1708334567.123
+dmarc_reports_total{domain="example.com",disposition="none",provider="Google"} 500.0
+dmarc_reports_total{domain="example.com",disposition="reject",provider="Google"} 20.0
+dmarc_last_processed_timestamp_seconds{domain="example.com",provider="Google"} 1708334567.123
 ```
 
 ---
 
-## **Installation & Usage**
+## Installation & Usage
 
-### **1️⃣ Clone the Repository**
+### 1. Clone the Repository
 ```sh
 git clone https://github.com/yourusername/dmarc-monitor.git
 cd dmarc-monitor
 ```
 
-### **2️⃣ Set Up Docker Compose**
-#### **Modify `docker-compose.yml` with Your Email Credentials**
-Edit the `environment` section in `docker-compose.yml`:
-```yaml
-environment:
-  EMAIL_USER: "your-email@example.com"
-  EMAIL_PASS: "your-email-password"
-  IMAP_SERVER: "imap.example.com"
+### 2. Create the Configuration File
+```sh
+cp config.example.toml config.toml
 ```
 
-### **3️⃣ Build & Start the Service**
-```sh
-docker-compose up -d --build
+Edit `config.toml` with your email credentials:
+```toml
+[email]
+username = "your-email@example.com"
+password = "your-app-password"
+imap_server = "imap.example.com"
 ```
+
+### 3. Build & Start the Service
+```sh
+docker compose up -d --build
+```
+
 This will:
-- **Build the Docker image**.
-- **Start the DMARC monitoring service**.
-- **Expose Prometheus metrics on port `8000`**.
+- Build the Docker image
+- Start the DMARC monitoring service
+- Expose Prometheus metrics on port `8000`
 
-### **4️⃣ Verify It’s Running**
-Check logs to see if it's processing DMARC reports:
+### 4. Verify It's Running
 ```sh
-docker-compose logs -f
+docker compose logs -f
 ```
 
-### **5️⃣ Query Prometheus Metrics**
-Go to:
+### 5. Query Prometheus Metrics
 ```
 http://localhost:8000/metrics
 ```
 
-### **6️⃣ Stop & Remove the Container**
-To stop the service, run:
+### 6. Stop & Remove the Container
 ```sh
-docker-compose down
+docker compose down
 ```
 
 ---
 
-## **Grafana Integration 📊**
+## Grafana Integration
 
-To visualize DMARC reports, **add Prometheus as a data source** in Grafana, and create a dashboard using the **exported metrics**.
+Add Prometheus as a data source in Grafana and create a dashboard using the exported metrics.
 
-Example **Prometheus Query for Passed Emails**:
+Example — passed emails by domain:
 ```promql
-sum(dmarc_passed_count) by (domain)
+sum(dmarc_reports_total{disposition="none"}) by (domain)
 ```
 
-Example **Prometheus Query for Failed Emails**:
+Example — rejected emails by domain:
 ```promql
-sum(dmarc_failed_count) by (domain)
+sum(dmarc_reports_total{disposition="reject"}) by (domain)
 ```
 
 ---
 
-## **Configuration Options**
+## Configuration Reference
 
-You can **modify the environment variables** to customize the setup:
+All configuration is done via a TOML file passed with `-c <path>`. See `config.example.toml` for a full example.
 
-| Variable     | Description                                  | Example Value              |
-|-------------|----------------------------------------------|----------------------------|
-| `EMAIL_USER` | Email address to fetch DMARC reports from | `your-email@example.com`   |
-| `EMAIL_PASS` | Email password (or App Password)          | `your-email-password`      |
-| `IMAP_SERVER` | IMAP server for your email provider       | `imap.gmail.com`           |
+| Key                    | Required | Default   | Description                                              |
+|------------------------|----------|-----------|----------------------------------------------------------|
+| `email.username`       | Yes      | —         | Email address to fetch DMARC reports from                |
+| `email.password`       | Yes      | —         | Email password or App Password                           |
+| `email.imap_server`    | Yes      | —         | IMAP server hostname                                     |
+| `email.folder`         | No       | `INBOX`   | IMAP folder to watch for unread mail                     |
+| `prometheus.port`      | No       | `8000`    | Port to expose the Prometheus metrics endpoint on        |
+| `prometheus.interval`  | No       | `60`      | Seconds between metric update cycles (minimum: 30)       |
 
-💡 **Tip:** If using Gmail, generate an **App Password** instead of using your real password.
+**Tip:** If using Gmail, generate an **App Password** instead of using your account password.
 
 ---
 
-## **Troubleshooting 🛠️**
+## Troubleshooting
 
-### **Container Not Running?**
-Check logs:
+### Container not running?
 ```sh
-docker-compose logs -f
+docker compose logs -f
 ```
 
-### **Metrics Not Updating?**
-- Ensure **emails are being received** at your inbox.
-- Check that **emails contain DMARC reports** in `.zip` or `.gz` format.
-- Run the script manually to debug:
-  ```sh
-  docker-compose up
-  ```
+### Metrics not updating?
+- Ensure emails with DMARC reports (`.zip` or `.gz` attachments) are arriving in the configured folder.
+- Check that the IMAP credentials and server are correct.
 
-### **Invalid Credentials?**
-- Make sure the **email/password** are correct.
-- **Use an App Password** instead of your real password (for Gmail, Outlook, etc.).
+### Invalid credentials?
+- Use an **App Password** instead of your real password (required for Gmail, Outlook, etc.).
 
 ---
 
-## **Contributing 🤝**
+## Contributing
 
 Feel free to open an **issue** or submit a **pull request** if you have improvements!
 
 ---
 
-## **License 📜**
+## License
 
 This project is open-source and licensed under the **MIT License**.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ DMARC Monitor is a **Prometheus-exporting service** that automatically fetches D
 - Automatically fetches DMARC reports from email attachments (`.zip` or `.gz`)
 - Parses XML reports and extracts relevant metrics
 - Exposes DMARC data via a **Prometheus metrics endpoint** (`:8000/metrics`)
-- Removes unnecessary `xmlns` namespaces for XML compatibility
+- Persists counter state across restarts (`data/dmarc_state.json`)
+- Structured logging via [loguru](https://github.com/Delgan/loguru), configurable log level
+- Graceful shutdown on SIGTERM / Ctrl+C
 - Deployable via Docker and Docker Compose
 - Configured via a TOML file (see `config.example.toml`)
 - Supports Grafana for visualization of DMARC trends over time
@@ -43,6 +45,8 @@ dmarc_reports_total{domain="example.com",disposition="reject",provider="Google"}
 dmarc_last_processed_timestamp_seconds{domain="example.com",provider="Google"} 1708334567.123
 ```
 
+Counter values survive restarts — state is persisted to `data/dmarc_state.json` and resumed on startup.
+
 ---
 
 ## Installation & Usage
@@ -73,6 +77,7 @@ docker compose up -d --build
 
 This will:
 - Build the Docker image
+- Mount `config.toml` read-only and `data/` for persistent state
 - Start the DMARC monitoring service
 - Expose Prometheus metrics on port `8000`
 
@@ -86,10 +91,12 @@ docker compose logs -f
 http://localhost:8000/metrics
 ```
 
-### 6. Stop & Remove the Container
+### 6. Stop the Service
 ```sh
 docker compose down
 ```
+
+The service shuts down gracefully on SIGTERM or Ctrl+C.
 
 ---
 
@@ -113,15 +120,17 @@ sum(dmarc_reports_total{disposition="reject"}) by (domain)
 
 All configuration is done via a TOML file passed with `-c <path>`. See `config.example.toml` for a full example.
 
-| Key                    | Required | Default   | Description                                              |
-|------------------------|----------|-----------|----------------------------------------------------------|
-| `email.username`       | Yes      | —         | Email address to fetch DMARC reports from                |
-| `email.password`       | Yes      | —         | Email password or App Password                           |
-| `email.imap_server`    | Yes      | —         | IMAP server hostname                                     |
-| `email.folder`         | No       | `INBOX`   | IMAP folder to watch for unread mail                     |
-| `email.archive_folder` | No       | `Archive` | IMAP folder to move processed mails into                 |
-| `prometheus.port`      | No       | `8000`    | Port to expose the Prometheus metrics endpoint on        |
-| `prometheus.interval`  | No       | `60`      | Seconds between metric update cycles (minimum: 30)       |
+| Key                    | Required | Default                  | Description                                              |
+|------------------------|----------|--------------------------|----------------------------------------------------------|
+| `email.username`       | Yes      | —                        | Email address to fetch DMARC reports from                |
+| `email.password`       | Yes      | —                        | Email password or App Password                           |
+| `email.imap_server`    | Yes      | —                        | IMAP server hostname                                     |
+| `email.folder`         | No       | `INBOX`                  | IMAP folder to watch for unread mail                     |
+| `email.archive_folder` | No       | `Archive`                | IMAP folder to move processed mails into                 |
+| `log.level`            | No       | `INFO`                   | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`           |
+| `prometheus.port`      | No       | `8000`                   | Port to expose the Prometheus metrics endpoint on        |
+| `prometheus.interval`  | No       | `60`                     | Seconds between metric update cycles (minimum: 30)       |
+| `state_file`           | No       | `data/dmarc_state.json`  | Path to persist counter state across restarts            |
 
 **Tip:** If using Gmail, generate an **App Password** instead of using your account password.
 

--- a/README.md
+++ b/README.md
@@ -119,10 +119,37 @@ All configuration is done via a TOML file passed with `-c <path>`. See `config.e
 | `email.password`       | Yes      | —         | Email password or App Password                           |
 | `email.imap_server`    | Yes      | —         | IMAP server hostname                                     |
 | `email.folder`         | No       | `INBOX`   | IMAP folder to watch for unread mail                     |
+| `email.archive_folder` | No       | `Archive` | IMAP folder to move processed mails into                 |
 | `prometheus.port`      | No       | `8000`    | Port to expose the Prometheus metrics endpoint on        |
 | `prometheus.interval`  | No       | `60`      | Seconds between metric update cycles (minimum: 30)       |
 
 **Tip:** If using Gmail, generate an **App Password** instead of using your account password.
+
+### Email filter rules
+
+Filter rules control which unread emails are processed. Each `[[email.filter]]` block defines one condition; an email is processed if it matches **at least one** block (OR). Within a block, **all** specified keys must match (AND). Matching is case-insensitive regex.
+
+Supported keys per block: `from`, `to`, `subject`.
+
+If no `[[email.filter]]` blocks are defined, all unread emails are processed.
+
+**Example:** process emails addressed to `dmarc-*` **or** with `DMARC` anywhere in the subject:
+
+```toml
+[[email.filter]]
+to = "dmarc-.*"
+
+[[email.filter]]
+subject = "DMARC"
+```
+
+**Example:** process only emails from Google that also mention DMARC in the subject (AND):
+
+```toml
+[[email.filter]]
+from = ".*@google\\.com"
+subject = "DMARC"
+```
 
 ---
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -16,3 +16,7 @@ folder = "INBOX"
 # (Optional) The port that Prometheus will expose
 # Default: 8000
 port = 8000
+
+# (Optional) The interval (in seconds) between updating metrics
+# Default: 60
+interval = 60

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,18 @@
+[email]
+# The email username to the account holding dmarc reports
+username = "user@example.com"
+
+# The password to the account holding dmarc reports
+password = "password"
+
+# The IMAP server with which to connect
+imap_server = "imap.example.com"
+
+# (Optional) The IMAP folder to watch for unread mail
+# Default: "INBOX"
+folder = "INBOX"
+
+[prometheus]
+# (Optional) The port that Prometheus will expose
+# Default: 8000
+port = 8000

--- a/config.example.toml
+++ b/config.example.toml
@@ -12,6 +12,23 @@ imap_server = "imap.example.com"
 # Default: "INBOX"
 folder = "INBOX"
 
+# (Optional) The IMAP folder to move processed mails into
+# Default: "Archive"
+archive_folder = "Archive"
+
+# (Optional) Filter rules for which emails to process.
+# Each [[email.filter]] block is one condition; conditions are OR-ed together.
+# Multiple keys within one block are AND-ed together.
+# Supported keys: from, to, subject (all regex, case-insensitive).
+# If no filter blocks are defined, all unread emails are processed.
+#
+# Example: process emails addressed to dmarc-* OR with "DMARC" in the subject:
+# [[email.filter]]
+# to = "dmarc-.*"
+#
+# [[email.filter]]
+# subject = "Report Domain"
+
 [prometheus]
 # (Optional) The port that Prometheus will expose
 # Default: 8000

--- a/config.example.toml
+++ b/config.example.toml
@@ -17,6 +17,6 @@ folder = "INBOX"
 # Default: 8000
 port = 8000
 
-# (Optional) The interval (in seconds) between updating metrics
+# (Optional) The interval (in seconds) between updating metrics (minimum: 30)
 # Default: 60
 interval = 60

--- a/config.example.toml
+++ b/config.example.toml
@@ -29,6 +29,11 @@ archive_folder = "Archive"
 # [[email.filter]]
 # subject = "Report Domain"
 
+[log]
+# (Optional) Log level: DEBUG, INFO, WARNING, ERROR
+# Default: INFO
+level = "INFO"
+
 [prometheus]
 # (Optional) The port that Prometheus will expose
 # Default: 8000

--- a/dmarc_monitor.py
+++ b/dmarc_monitor.py
@@ -158,12 +158,21 @@ def parse_dmarc_report(xml_data):
 
 def update_metrics():
     """Periodically fetches new emails, extracts, and updates metrics."""
+    try:
+        interval = CONFIG["prometheus"].get("interval", 60)
+    except KeyError:
+        pass
+
+    if interval < 30:
+        print("Warning: Configured interval too low; Setting minimum 30 seconds")
+        interval = 30
     while True:
         xml_reports = extract_dmarc_reports()
         if xml_reports:
             for xml_data in xml_reports:
                 parse_dmarc_report(xml_data)
-        time.sleep(60)
+
+        time.sleep(interval)
 
 
 def main():

--- a/dmarc_monitor.py
+++ b/dmarc_monitor.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import time
 import xml.etree.ElementTree as ET

--- a/dmarc_monitor.py
+++ b/dmarc_monitor.py
@@ -6,7 +6,6 @@ import xml.etree.ElementTree as ET
 import zipfile
 import gzip
 import imaplib
-import email
 import re
 from prometheus_client import start_http_server, Gauge
 from email import policy

--- a/dmarc_monitor.py
+++ b/dmarc_monitor.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
 
+import gzip
+import imaplib
 import os
+import re
 import time
 import xml.etree.ElementTree as ET
 import zipfile
-import gzip
-import imaplib
-import re
-from prometheus_client import start_http_server, Gauge
 from email import policy
 from email.parser import BytesParser
 from io import BytesIO
+
+from prometheus_client import start_http_server, Gauge
+
 
 # Read email credentials from environment variables
 EMAIL_USER = os.getenv("EMAIL_USER")

--- a/dmarc_monitor.py
+++ b/dmarc_monitor.py
@@ -27,8 +27,8 @@ dmarc_failed = Gauge(
     'Number of emails that failed DMARC',
     ['domain', 'provider', 'report_id', 'report_date']
 )
-last_processed_timestamp = Gauge(
-    'last_processed_timestamp',
+dmarc_last_processed_timestamp_seconds = Gauge(
+    'dmarc_last_processed_timestamp_seconds',
     'Timestamp of last processed DMARC report',
     ['domain', 'provider', 'report_id', 'report_date']
 )
@@ -137,7 +137,7 @@ def parse_dmarc_report(xml_data):
         # Update Prometheus metrics with labels
         dmarc_passed.labels(domain=domain, provider=org_name, report_id=report_id, report_date=report_date).inc(passed_count)
         dmarc_failed.labels(domain=domain, provider=org_name, report_id=report_id, report_date=report_date).inc(failed_count)
-        last_processed_timestamp.labels(domain=domain, provider=org_name, report_id=report_id, report_date=report_date).set(time.time())
+        dmarc_last_processed_timestamp_seconds.labels(domain=domain, provider=org_name, report_id=report_id, report_date=report_date).set(time.time())
 
         print(f"Updated metrics - Domain: {domain}, Provider: {org_name}, Report ID: {report_id}, Date: {report_date}, Passed: {passed_count}, Failed: {failed_count}")
 

--- a/dmarc_monitor.py
+++ b/dmarc_monitor.py
@@ -4,6 +4,7 @@ import argparse
 import gzip
 import imaplib
 import re
+import sys
 import time
 import tomllib
 import zipfile
@@ -13,7 +14,15 @@ from io import BytesIO
 from pathlib import Path
 
 import defusedxml.ElementTree as ET
-from prometheus_client import Counter, Gauge, start_http_server
+from loguru import logger
+from prometheus_client import (
+    GC_COLLECTOR, PLATFORM_COLLECTOR, PROCESS_COLLECTOR, REGISTRY,
+    Counter, Gauge, start_http_server,
+)
+
+REGISTRY.unregister(GC_COLLECTOR)
+REGISTRY.unregister(PLATFORM_COLLECTOR)
+REGISTRY.unregister(PROCESS_COLLECTOR)
 
 dmarc_reports_total = Counter(
     'dmarc_reports_total',
@@ -36,13 +45,19 @@ ARGS = ARGPARSER.parse_args()
 with open(Path(ARGS.config), "rb") as f:
     CONFIG = tomllib.load(f)
 
+log_level = CONFIG.get("log", {}).get("level", "INFO").upper()
+logger.remove()
+logger.add(sys.stderr, level=log_level,
+           format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | {message}")
+
 
 def check_imap_folders():
+    source = CONFIG["email"].get("folder", "INBOX")
+    archive = CONFIG["email"].get("archive_folder", "Archive")
+    logger.info("Checking IMAP folders: '{}' and '{}'", source, archive)
     try:
         mail = imaplib.IMAP4_SSL(CONFIG["email"]["imap_server"])
         mail.login(CONFIG["email"]["username"], CONFIG["email"]["password"])
-        source = CONFIG["email"].get("folder", "INBOX")
-        archive = CONFIG["email"].get("archive_folder", "Archive")
         missing = []
         for folder in dict.fromkeys([source, archive]):
             result, _ = mail.select(f'"{folder}"')
@@ -51,6 +66,7 @@ def check_imap_folders():
         mail.logout()
         if missing:
             raise SystemExit(f"IMAP folder(s) not found: {', '.join(missing)}")
+        logger.info("IMAP folders OK: '{}' → '{}'", source, archive)
     except SystemExit:
         raise
     except Exception as e:
@@ -72,31 +88,45 @@ def _matches_filter(msg):
 def get_email_attachments():
     attachments = []
     archive_folder = CONFIG["email"].get("archive_folder", "Archive")
+    folder = CONFIG["email"].get("folder", "INBOX")
+    logger.debug("Connecting to {}", CONFIG["email"]["imap_server"])
     try:
         mail = imaplib.IMAP4_SSL(CONFIG["email"]["imap_server"])
         mail.login(CONFIG["email"]["username"], CONFIG["email"]["password"])
-        mail.select(CONFIG["email"].get("folder", "INBOX"))
+        mail.select(folder)
 
         result, data = mail.search(None, '(UNSEEN)')
         if result == 'OK':
-            for num in data[0].split():
+            msg_nums = data[0].split()
+            logger.debug("Found {} unseen message(s) in '{}'", len(msg_nums), folder)
+            for num in msg_nums:
                 result, msg_data = mail.fetch(num, '(RFC822)')
                 if result != 'OK':
+                    logger.warning("Failed to fetch message #{}", num.decode())
                     continue
                 msg = BytesParser(policy=policy.default).parsebytes(msg_data[0][1])
+                subject = msg.get("subject", "(no subject)")
+                sender = msg.get("from", "(unknown sender)")
                 if not _matches_filter(msg):
+                    logger.debug("Skipping (filter no match): subject='{}', from='{}'", subject, sender)
                     continue
+                logger.debug("Processing: subject='{}', from='{}'", subject, sender)
+                found = 0
                 for part in msg.iter_attachments():
                     filename = part.get_filename()
                     if filename and (filename.endswith('.zip') or filename.endswith('.gz')):
+                        logger.debug("Found attachment: {}", filename)
                         attachments.append((filename, part.get_payload(decode=True)))
+                        found += 1
+                if found == 0:
+                    logger.debug("No DMARC attachments in: subject='{}'", subject)
                 mail.store(num, '+FLAGS', '\\Seen')
                 mail.copy(num, f'"{archive_folder}"')
                 mail.store(num, '+FLAGS', '\\Deleted')
             mail.expunge()
         mail.logout()
     except Exception as e:
-        print(f"Error retrieving emails: {e}")
+        logger.error("Error retrieving emails: {}", e)
     return attachments
 
 
@@ -106,7 +136,7 @@ def clean_xml(xml_data):
         ET.fromstring(cleaned)
         return cleaned
     except Exception:
-        print("Invalid XML detected. Skipping.")
+        logger.warning("Invalid XML detected, skipping")
         return None
 
 
@@ -118,9 +148,11 @@ def extract_dmarc_reports():
             with zipfile.ZipFile(BytesIO(file_data), 'r') as zf:
                 for name in zf.namelist():
                     if name.endswith('.xml'):
+                        logger.debug("Extracting XML from zip: {} → {}", filename, name)
                         with zf.open(name) as xml_file:
                             extracted_xml = xml_file.read().decode('utf-8')
         elif filename.endswith('.gz'):
+            logger.debug("Extracting XML from gz: {}", filename)
             with gzip.open(BytesIO(file_data), 'rb') as gz_file:
                 extracted_xml = gz_file.read().decode('utf-8')
         if extracted_xml:
@@ -143,6 +175,7 @@ def parse_dmarc_report(xml_data):
         domain_el = root.find('.//policy_published/domain')
         domain = domain_el.text if domain_el is not None else "unknown"
 
+        disposition_counts = {}
         for record in root.findall('.//record'):
             count_el = record.find('./row/count')
             disposition_el = record.find('./row/policy_evaluated/disposition')
@@ -154,25 +187,35 @@ def parse_dmarc_report(xml_data):
             dmarc_reports_total.labels(
                 domain=domain, provider=org_name, disposition=disposition
             ).inc(count)
+            disposition_counts[disposition] = disposition_counts.get(disposition, 0) + count
 
         dmarc_last_processed_timestamp_seconds.labels(
             domain=domain, provider=org_name
         ).set(time.time())
-        print(f"Processed report — domain: {domain}, provider: {org_name}")
+
+        counts_str = ", ".join(f"{d}={n}" for d, n in disposition_counts.items())
+        logger.info("Processed report — provider: {}, domain: {}, counts: [{}]",
+                    org_name, domain, counts_str)
 
     except Exception as e:
-        print(f"Error parsing DMARC XML: {e}")
+        logger.error("Error parsing DMARC XML: {}", e)
 
 
 def update_metrics():
     interval = max(CONFIG.get("prometheus", {}).get("interval", 60), 30)
     while True:
-        for xml_data in extract_dmarc_reports():
+        logger.debug("Checking mailbox for new DMARC reports...")
+        reports = extract_dmarc_reports()
+        if not reports:
+            logger.debug("No new DMARC reports found")
+        for xml_data in reports:
             parse_dmarc_report(xml_data)
+        logger.debug("Next check in {}s", interval)
         time.sleep(interval)
 
 
 def main():
+    logger.info("dmarc_monitor starting up")
     email_cfg = CONFIG.get("email", {})
     missing = [k for k in ("username", "password", "imap_server") if not email_cfg.get(k)]
     if missing:
@@ -182,7 +225,7 @@ def main():
 
     port = CONFIG.get("prometheus", {}).get("port", 8000)
     start_http_server(port)
-    print(f"Started dmarc_monitor. Prometheus metrics on :{port}")
+    logger.info("Prometheus metrics server started on :{}", port)
     update_metrics()
 
 

--- a/dmarc_monitor.py
+++ b/dmarc_monitor.py
@@ -6,38 +6,31 @@ import imaplib
 import re
 import time
 import tomllib
-import xml.etree.ElementTree as ET
 import zipfile
 from email import policy
 from email.parser import BytesParser
 from io import BytesIO
 from pathlib import Path
 
-from prometheus_client import start_http_server, Gauge
+import defusedxml.ElementTree as ET
+from prometheus_client import Counter, Gauge, start_http_server
 
-
-# Define Prometheus metrics with labels (domain, provider, report_id, report_date)
-dmarc_passed = Gauge(
-    'dmarc_passed_count',
-    'Number of emails that passed DMARC',
-    ['domain', 'provider', 'report_id', 'report_date']
-)
-dmarc_failed = Gauge(
-    'dmarc_failed_count',
-    'Number of emails that failed DMARC',
-    ['domain', 'provider', 'report_id', 'report_date']
+dmarc_reports_total = Counter(
+    'dmarc_reports_total',
+    'Total DMARC disposition counts from processed reports',
+    ['domain', 'provider', 'disposition']
 )
 dmarc_last_processed_timestamp_seconds = Gauge(
     'dmarc_last_processed_timestamp_seconds',
-    'Timestamp of last processed DMARC report',
-    ['domain', 'provider', 'report_id', 'report_date']
+    'Unix timestamp of the last processed DMARC report',
+    ['domain', 'provider']
 )
 
 ARGPARSER = argparse.ArgumentParser(
     description="Fetch, parse, and export Prometheus metrics from DMARC mail."
 )
 ARGPARSER.add_argument("-c", "--config", type=str, required=True,
-                       help="load specified configuration file")
+                       help="path to TOML configuration file")
 ARGS = ARGPARSER.parse_args()
 
 with open(Path(ARGS.config), "rb") as f:
@@ -45,155 +38,111 @@ with open(Path(ARGS.config), "rb") as f:
 
 
 def get_email_attachments():
-    """Connects to an email inbox and retrieves DMARC report attachments."""
     attachments = []
-
     try:
         mail = imaplib.IMAP4_SSL(CONFIG["email"]["imap_server"])
         mail.login(CONFIG["email"]["username"], CONFIG["email"]["password"])
         mail.select(CONFIG["email"].get("folder", "INBOX"))
 
-        # Search for unread emails with attachments
         result, data = mail.search(None, '(UNSEEN)')
-
         if result == 'OK':
             for num in data[0].split():
                 result, msg_data = mail.fetch(num, '(RFC822)')
                 if result != 'OK':
                     continue
-
                 msg = BytesParser(policy=policy.default).parsebytes(msg_data[0][1])
-
                 for part in msg.iter_attachments():
                     filename = part.get_filename()
                     if filename and (filename.endswith('.zip') or filename.endswith('.gz')):
                         attachments.append((filename, part.get_payload(decode=True)))
-
-                # Mark email as seen
                 mail.store(num, '+FLAGS', '\\Seen')
-
         mail.logout()
-
     except Exception as e:
         print(f"Error retrieving emails: {e}")
-
     return attachments
 
-def clean_xml(xml_data):
-    """Strips unwanted characters, removes namespaces, and validates XML format."""
-    cleaned_xml = xml_data.replace('\r\n', '').replace('\n', '').strip()
-    
-    # Remove XML namespace definitions
-    cleaned_xml = re.sub(r'xmlns="[^"]+"', '', cleaned_xml)
 
-    # Check if XML is still valid
+def clean_xml(xml_data):
+    cleaned = re.sub(r'xmlns="[^"]+"', '', xml_data.replace('\r\n', '').replace('\n', '')).strip()
     try:
-        ET.fromstring(cleaned_xml)
-        return cleaned_xml  # Return only if valid
-    except ET.ParseError:
+        ET.fromstring(cleaned)
+        return cleaned
+    except Exception:
         print("Invalid XML detected. Skipping.")
-        return None  # Skip invalid XMLs
+        return None
+
 
 def extract_dmarc_reports():
-    """Extracts DMARC XML reports from email attachments."""
     xml_reports = []
-    attachments = get_email_attachments()
-
-    for filename, file_data in attachments:
+    for filename, file_data in get_email_attachments():
         extracted_xml = None
-
         if filename.endswith('.zip'):
             with zipfile.ZipFile(BytesIO(file_data), 'r') as zf:
                 for name in zf.namelist():
                     if name.endswith('.xml'):
                         with zf.open(name) as xml_file:
                             extracted_xml = xml_file.read().decode('utf-8')
-
         elif filename.endswith('.gz'):
             with gzip.open(BytesIO(file_data), 'rb') as gz_file:
                 extracted_xml = gz_file.read().decode('utf-8')
-
         if extracted_xml:
-            cleaned_xml = clean_xml(extracted_xml)
-            if cleaned_xml:
-                xml_reports.append(cleaned_xml)
-
+            cleaned = clean_xml(extracted_xml)
+            if cleaned:
+                xml_reports.append(cleaned)
     return xml_reports
 
 
 def parse_dmarc_report(xml_data):
-    """Parses a single DMARC XML report and updates Prometheus metrics."""
     try:
         root = ET.fromstring(xml_data)
 
-        # Extract domain, provider, report ID, and date
         report_metadata = root.find('.//report_metadata')
-        org_name = report_metadata.find('org_name').text if report_metadata.find('org_name') is not None else "unknown"
-        report_id = report_metadata.find('report_id').text if report_metadata.find('report_id') is not None else "unknown"
-        date_range = report_metadata.find('date_range')
-        report_date = time.strftime('%Y-%m-%d', time.gmtime(int(date_range.find('begin').text))) if date_range is not None else "unknown"
-        domain = root.find('.//policy_published/domain').text if root.find('.//policy_published/domain') is not None else "unknown"
-
-        passed_count = 0
-        failed_count = 0
+        org_name = (
+            report_metadata.find('org_name').text
+            if report_metadata is not None and report_metadata.find('org_name') is not None
+            else "unknown"
+        )
+        domain_el = root.find('.//policy_published/domain')
+        domain = domain_el.text if domain_el is not None else "unknown"
 
         for record in root.findall('.//record'):
-            count = int(record.find('./row/count').text)
-            disposition = record.find('./row/policy_evaluated/disposition').text
+            count_el = record.find('./row/count')
+            disposition_el = record.find('./row/policy_evaluated/disposition')
+            if count_el is None or disposition_el is None:
+                continue
+            count = int(count_el.text)
+            # 'none' = pass, 'quarantine' = soft-fail, 'reject' = hard-fail
+            disposition = disposition_el.text or "unknown"
+            dmarc_reports_total.labels(
+                domain=domain, provider=org_name, disposition=disposition
+            ).inc(count)
 
-            if disposition in ['none', 'quarantine']:
-                passed_count += count
-            else:
-                failed_count += count
+        dmarc_last_processed_timestamp_seconds.labels(
+            domain=domain, provider=org_name
+        ).set(time.time())
+        print(f"Processed report — domain: {domain}, provider: {org_name}")
 
-        # Update Prometheus metrics with labels
-        dmarc_passed.labels(domain=domain, provider=org_name, report_id=report_id, report_date=report_date).inc(passed_count)
-        dmarc_failed.labels(domain=domain, provider=org_name, report_id=report_id, report_date=report_date).inc(failed_count)
-        dmarc_last_processed_timestamp_seconds.labels(domain=domain, provider=org_name, report_id=report_id, report_date=report_date).set(time.time())
+    except Exception as e:
+        print(f"Error parsing DMARC XML: {e}")
 
-        print(f"Updated metrics - Domain: {domain}, Provider: {org_name}, Report ID: {report_id}, Date: {report_date}, Passed: {passed_count}, Failed: {failed_count}")
-
-    except ET.ParseError:
-        print("Error parsing DMARC XML")
 
 def update_metrics():
-    """Periodically fetches new emails, extracts, and updates metrics."""
-    try:
-        interval = CONFIG["prometheus"].get("interval", 60)
-    except KeyError:
-        pass
-
-    if interval < 30:
-        print("Warning: Configured interval too low; Setting minimum 30 seconds")
-        interval = 30
+    interval = max(CONFIG.get("prometheus", {}).get("interval", 60), 30)
     while True:
-        xml_reports = extract_dmarc_reports()
-        if xml_reports:
-            for xml_data in xml_reports:
-                parse_dmarc_report(xml_data)
-
+        for xml_data in extract_dmarc_reports():
+            parse_dmarc_report(xml_data)
         time.sleep(interval)
 
 
 def main():
-    """Starts the Prometheus server and monitoring loop."""
+    email_cfg = CONFIG.get("email", {})
+    missing = [k for k in ("username", "password", "imap_server") if not email_cfg.get(k)]
+    if missing:
+        raise SystemExit(f"Missing required config keys: {', '.join(f'email.{k}' for k in missing)}")
 
-    try:
-        assert CONFIG["email"]["username"]
-        assert CONFIG["email"]["password"]
-        assert CONFIG["email"]["imap_server"]
-    except KeyError as err:
-        raise KeyError("Invalid config file. Refer to the example file.") from err
-
-    # Start Prometheus HTTP server
-    try:
-        prom_port = CONFIG["prometheus"].get("port", 8000)
-    except KeyError:
-        pass
-    start_http_server(prom_port)
-    print(f"Started dmarc_monitor server. Listening on :{prom_port}...")
-
-    # Start monitoring loop
+    port = CONFIG.get("prometheus", {}).get("port", 8000)
+    start_http_server(port)
+    print(f"Started dmarc_monitor. Prometheus metrics on :{port}")
     update_metrics()
 
 

--- a/dmarc_monitor.py
+++ b/dmarc_monitor.py
@@ -37,8 +37,41 @@ with open(Path(ARGS.config), "rb") as f:
     CONFIG = tomllib.load(f)
 
 
+def check_imap_folders():
+    try:
+        mail = imaplib.IMAP4_SSL(CONFIG["email"]["imap_server"])
+        mail.login(CONFIG["email"]["username"], CONFIG["email"]["password"])
+        source = CONFIG["email"].get("folder", "INBOX")
+        archive = CONFIG["email"].get("archive_folder", "Archive")
+        missing = []
+        for folder in dict.fromkeys([source, archive]):
+            result, _ = mail.select(f'"{folder}"')
+            if result != 'OK':
+                missing.append(folder)
+        mail.logout()
+        if missing:
+            raise SystemExit(f"IMAP folder(s) not found: {', '.join(missing)}")
+    except SystemExit:
+        raise
+    except Exception as e:
+        raise SystemExit(f"IMAP connection failed during folder check: {e}")
+
+
+def _matches_filter(msg):
+    conditions = CONFIG["email"].get("filter", [])
+    if not conditions:
+        return True
+    # OR between blocks, AND within each block
+    return any(
+        all(re.search(pattern, msg.get(header, ""), re.IGNORECASE)
+            for header, pattern in condition.items())
+        for condition in conditions
+    )
+
+
 def get_email_attachments():
     attachments = []
+    archive_folder = CONFIG["email"].get("archive_folder", "Archive")
     try:
         mail = imaplib.IMAP4_SSL(CONFIG["email"]["imap_server"])
         mail.login(CONFIG["email"]["username"], CONFIG["email"]["password"])
@@ -51,11 +84,16 @@ def get_email_attachments():
                 if result != 'OK':
                     continue
                 msg = BytesParser(policy=policy.default).parsebytes(msg_data[0][1])
+                if not _matches_filter(msg):
+                    continue
                 for part in msg.iter_attachments():
                     filename = part.get_filename()
                     if filename and (filename.endswith('.zip') or filename.endswith('.gz')):
                         attachments.append((filename, part.get_payload(decode=True)))
                 mail.store(num, '+FLAGS', '\\Seen')
+                mail.copy(num, f'"{archive_folder}"')
+                mail.store(num, '+FLAGS', '\\Deleted')
+            mail.expunge()
         mail.logout()
     except Exception as e:
         print(f"Error retrieving emails: {e}")
@@ -139,6 +177,8 @@ def main():
     missing = [k for k in ("username", "password", "imap_server") if not email_cfg.get(k)]
     if missing:
         raise SystemExit(f"Missing required config keys: {', '.join(f'email.{k}' for k in missing)}")
+
+    check_imap_folders()
 
     port = CONFIG.get("prometheus", {}).get("port", 8000)
     start_http_server(port)

--- a/dmarc_monitor.py
+++ b/dmarc_monitor.py
@@ -3,8 +3,11 @@
 import argparse
 import gzip
 import imaplib
+import json
 import re
+import signal
 import sys
+import threading
 import time
 import tomllib
 import zipfile
@@ -49,6 +52,50 @@ log_level = CONFIG.get("log", {}).get("level", "INFO").upper()
 logger.remove()
 logger.add(sys.stderr, level=log_level,
            format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | {message}")
+
+# In-memory state: "domain\x00provider\x00disposition" -> cumulative count
+_state: dict[str, int] = {}
+_stop_event = threading.Event()
+
+
+def _handle_shutdown(signum, frame):
+    logger.info("Shutdown signal received, stopping...")
+    _stop_event.set()
+
+
+signal.signal(signal.SIGTERM, _handle_shutdown)
+signal.signal(signal.SIGINT, _handle_shutdown)
+
+
+def _state_path() -> Path:
+    return Path(CONFIG.get("state_file", "data/dmarc_state.json"))
+
+
+def load_state():
+    path = _state_path()
+    if not path.exists():
+        logger.info("No state file found at {}, starting fresh", path)
+        return
+    try:
+        with open(path) as f:
+            saved = json.load(f)
+        for key, count in saved.items():
+            _state[key] = count
+            domain, provider, disposition = key.split("\x00", 2)
+            dmarc_reports_total.labels(
+                domain=domain, provider=provider, disposition=disposition
+            ).inc(count)
+        logger.info("Resumed state from {} ({} series)", path, len(_state))
+    except Exception as e:
+        logger.warning("Could not load state file, starting fresh: {}", e)
+
+
+def _save_state():
+    try:
+        with open(_state_path(), "w") as f:
+            json.dump(_state, f, indent=2)
+    except Exception as e:
+        logger.error("Could not save state: {}", e)
 
 
 def check_imap_folders():
@@ -188,10 +235,14 @@ def parse_dmarc_report(xml_data):
                 domain=domain, provider=org_name, disposition=disposition
             ).inc(count)
             disposition_counts[disposition] = disposition_counts.get(disposition, 0) + count
+            key = f"{domain}\x00{org_name}\x00{disposition}"
+            _state[key] = _state.get(key, 0) + count
 
         dmarc_last_processed_timestamp_seconds.labels(
             domain=domain, provider=org_name
         ).set(time.time())
+
+        _save_state()
 
         counts_str = ", ".join(f"{d}={n}" for d, n in disposition_counts.items())
         logger.info("Processed report — provider: {}, domain: {}, counts: [{}]",
@@ -203,7 +254,7 @@ def parse_dmarc_report(xml_data):
 
 def update_metrics():
     interval = max(CONFIG.get("prometheus", {}).get("interval", 60), 30)
-    while True:
+    while not _stop_event.is_set():
         logger.debug("Checking mailbox for new DMARC reports...")
         reports = extract_dmarc_reports()
         if not reports:
@@ -211,7 +262,8 @@ def update_metrics():
         for xml_data in reports:
             parse_dmarc_report(xml_data)
         logger.debug("Next check in {}s", interval)
-        time.sleep(interval)
+        _stop_event.wait(timeout=interval)
+    logger.info("Stopped.")
 
 
 def main():
@@ -221,6 +273,7 @@ def main():
     if missing:
         raise SystemExit(f"Missing required config keys: {', '.join(f'email.{k}' for k in missing)}")
 
+    load_state()
     check_imap_folders()
 
     port = CONFIG.get("prometheus", {}).get("port", 8000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ services:
     build: .
     ports:
       - "8000:8000"
-    environment:
-      EMAIL_USER: "your-email@example.com"
-      EMAIL_PASS: "your-email-password"
-      IMAP_SERVER: "imap.example.com"
+    volumes:
+      - ./config.toml:/app/config.toml:ro
     restart: always
+    command: ["-c", "config.toml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,6 @@ services:
       - "8000:8000"
     volumes:
       - ./config.toml:/app/config.toml:ro
+      - ./data:/app/data
     restart: unless-stopped
     command: ["-c", "/app/config.toml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,5 @@ services:
       - "8000:8000"
     volumes:
       - ./config.toml:/app/config.toml:ro
-    restart: always
-    command: ["-c", "config.toml"]
+    restart: unless-stopped
+    command: ["-c", "/app/config.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+
+name = "dmarc-monitor"
+version = "0.2.0"
+license = {text = "MIT"}
+dependencies = [
+    "prometheus_client"
+]
+
+[project.scripts]
+dmarc-monitor = "dmarc_monitor:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,19 @@
 [project]
-
 name = "dmarc-monitor"
-version = "0.2.0"
+version = "0.3.0"
 license = {text = "MIT"}
+requires-python = ">=3.11"
 dependencies = [
-    "prometheus_client"
+    "defusedxml>=0.7.1",
+    "prometheus_client>=0.21.1",
 ]
 
 [project.scripts]
 dmarc-monitor = "dmarc_monitor:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["dmarc_monitor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
     "defusedxml>=0.7.1",
+    "loguru>=0.7",
     "prometheus_client>=0.21.1",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-prometheus_client


### PR DESCRIPTION
Hi! I've been running this in production and built up a significant set of improvements — both on my own and building on top of [@ainola's open PR #1](https://github.com/hechi/dmarc-monitor/pull/1). I'd love to contribute it all back upstream. Happy to split into smaller PRs if that's easier to review.

## Built on ainola's work (PR #1)

[@ainola's PR](https://github.com/hechi/dmarc-monitor/pull/1) lays the foundation this work builds on:
- `pyproject.toml` replacing `requirements.txt`
- TOML config file (separating secrets from code)
- Proper Prometheus metric naming (`_seconds` suffix, `dmarc_` prefix)
- Configurable poll interval
- Shebang, cleaned-up imports

## Additional changes

### Security hardening
- **XXE/billion-laughs protection**: replaced `xml.etree.ElementTree` with `defusedxml`
- **Non-root Docker container**: dedicated `appuser`/`appgroup` system user
- **GitHub Actions pinned to SHA hashes** for supply chain security
- **Trivy vulnerability scan** in the release workflow — blocks on CRITICAL findings, attaches SBOM to each release

### Prometheus metric design
- **`Gauge` → `Counter`** for `dmarc_reports_total`: disposition counts are monotonically increasing
- **Removed high-cardinality labels** (`report_id`, `report_date`) — prevents cardinality explosion over time
- **`disposition` as a label value** (`none`/`quarantine`/`reject`) — makes PromQL aggregation natural
- **Default collectors removed** (GC, process, platform) — `/metrics` only exposes DMARC-relevant metrics

### CI/CD
- **GitHub Container Registry** instead of Docker Hub — uses `GITHUB_TOKEN`, no extra secrets needed
- **Multi-arch builds** (linux/amd64 + linux/arm64)
- **GHA build cache** to speed up CI
- **`softprops/action-gh-release`** replaces the unmaintained `antonyurchenko/git-release`
- **`docker/metadata-action`** for proper semver tag generation

### Dockerfile
- Base image updated to `python:3.13-slim`
- `HEALTHCHECK` added
- `PYTHONUNBUFFERED=1` so logs appear immediately in `docker logs`

### Email archiving and filter rules
- **Archive folder**: processed emails are moved to a configurable IMAP folder (default: `Archive`) instead of just being deleted
- **Startup folder validation**: source and archive folders are verified to exist before the main loop starts
- **Filter rules** (`[[email.filter]]`): header-based allowlist (OR between blocks, AND within). Supported keys: `from`, `to`, `subject` — all case-insensitive regex

### Structured logging (loguru)
- `DEBUG`: per-mail details (subject, sender, attachments), mailbox polls
- `INFO`: startup, folder check, each processed report with provider/domain/counts
- `WARNING`/`ERROR`: all failure cases
- Log level configurable via `[log] level` in config (default: `INFO`)

### State persistence
- Counter values written to `data/dmarc_state.json` after each report, resumed on startup — totals survive container restarts
- Path configurable via `state_file` in config

### Graceful shutdown
- `threading.Event` replaces `time.sleep()` — exits immediately on SIGTERM/Ctrl+C instead of waiting out the full poll interval

---

## Breaking changes

| What | Before | After |
|------|--------|-------|
| `dmarc_reports_total` type | `Gauge` | `Counter` — Prometheus/Grafana queries using gauge-specific functions need updating |
| Metric labels | included `report_id`, `report_date` | removed — queries filtering on those labels will break |
| Docker image registry | Docker Hub | GHCR (`ghcr.io/<owner>/dmarc-monitor`) |
| Docker Compose | no `data/` volume | `./data` directory must exist (included as `data/.gitkeep`) |

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)